### PR TITLE
Use non-free-firmware on bookworm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,6 @@ OPTIONS (= is mandatory):
 
             type: str
 
-- debian_backports_components
-        Debian-backports apt repo components
-        [Default: (null)]
-        type: str
-
 - debian_mirror
         Debian apt mirror URL
         [Default: http://deb.debian.org/debian/]

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ OPTIONS (= is mandatory):
         [Default: (null)]
         type: str
 
+- hostname_strategy
+        Strategy to use when updating the hostname, see https://docs.a
+        nsible.com/ansible/latest/collections/ansible/builtin/hostname
+        _module.html#parameter-use
+        default: systemd
+        type: str
+
 - modprobe_blacklist_config_file
         Path for the file containing a list of blacklisted kernel
         modules

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ packages_upgrade: []
 packages_remove: []
 packages_purge: []
 
+hostname_strategy: systemd
+
 modprobe_modules: []
 modprobe_modules_load_file: "/etc/modules-load.d/ansible.conf"
 modprobe_options_config_file: "/etc/modprobe.d/zz-ansible-options.conf"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,6 @@ debian_mirror: "http://deb.debian.org/debian/"
 ubuntu_mirror: "http://archive.ubuntu.com/ubuntu/"
 raspbian_mirror: "http://raspbian.raspberrypi.org/raspbian/"
 raspi_mirror: "http://archive.raspberrypi.org/debian/"
-debian_backports_components: "{{ ansible_distribution_release }}-backports main contrib non-free"
 
 grub_cmdline: []
 grub_serial_console: ""

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -115,10 +115,6 @@ argument_specs:
         type: str
         default: http://archive.raspberrypi.org/debian/
 
-      debian_backports_components:
-        description: Debian-backports apt repo components
-        type: str
-
       grub_cmdline:
         description: GRUB commandline default options
         type: list

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -59,6 +59,13 @@ argument_specs:
         type: list
         elements: str
 
+      hostname_strategy:
+        description: |
+          Strategy to use when updating the hostname,
+          see https://docs.ansible.com/ansible/latest/collections/ansible/builtin/hostname_module.html#parameter-use
+        type: str
+        default: systemd
+
       modprobe_modules:
         description: List of kernel modules to manage
         type: list

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -10,30 +10,14 @@
         ubuntu_mirror: "https://mirror.fsmg.org.nz/ubuntu/"
 
         apt_repos:
-          - name: wand-libwandio
+          - name: tailscale
             repo: >-
-              deb [signed-by=/etc/apt/keyrings/wand-libwandio.gpg]
-              https://dl.cloudsmith.io/public/wand/libwandio/deb/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main
+              deb [signed-by=/etc/apt/keyrings/tailscale.gpg]
+              https://pkgs.tailscale.com/stable/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main
             key:
-              url: https://dl.cloudsmith.io/public/wand/libwandio/gpg.69A507877C4B94E8.key
-              id: 54B22D514CCD2F1060E195AD69A507877C4B94E8
-              keyring: /etc/apt/keyrings/wand-libwandio.gpg
-          - name: wand-libwandder
-            repo: >-
-              deb [signed-by=/etc/apt/keyrings/wand-libwandder.gpg]
-              https://dl.cloudsmith.io/public/wand/libwandder/deb/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main
-            key:
-              url: https://dl.cloudsmith.io/public/wand/libwandder/gpg.850A47EB27EE6871.key
-              id: 9303641FB1EA5BC0E7527327850A47EB27EE6871
-              keyring: /etc/apt/keyrings/wand-libwandder.gpg
-          - name: wand-libtrace
-            repo: >-
-              deb [signed-by=/etc/apt/keyrings/wand-libtrace.gpg]
-              https://dl.cloudsmith.io/public/wand/libtrace/deb/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main
-            key:
-              url: https://dl.cloudsmith.io/public/wand/libtrace/gpg.4DA49CA206D589FA.key
-              id: 34C301C4F83705A7B73E1A2A4DA49CA206D589FA
-              keyring: /etc/apt/keyrings/wand-libtrace.gpg
+              url: https://pkgs.tailscale.com/stable/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}.asc
+              id: 2596A99EAAB33821893C0A79458CA832957F5868
+              keyring: /etc/apt/keyrings/tailscale.gpg
 
   environment:
     ANSIBLE_UNSAFE_WRITES: "true"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,7 +10,8 @@ platforms:
     override_command: false
     privileged: true
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
 provisioner:
   name: ansible
   log: true

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,12 +1,17 @@
 ---
-
-- name: Enable backports repo on debian
-  ansible.builtin.apt_repository:
-    filename: "debian-backports"
-    repo: "deb {{ debian_mirror }} {{ debian_backports_components }}"
-    update_cache: yes
-    state: present
+- name: "Enable backports repo on debian"
+  ansible.builtin.template:
+    src: "templates/sources.list.debian-backports"
+    dest: "/etc/apt/sources.list.d/debian-backports.list"
+    owner: root
+    group: root
+    mode: u=rw,g=r,o=r
   register: _apt_enable_debian_backports
+
+- name: "Refresh apt cache when mirror changes"  # noqa no-handler
+  ansible.builtin.apt:
+    update_cache: yes
+  when: _apt_enable_debian_backports.changed
 
 - name: Install needrestart from backports on debian stretch  # noqa package-latest no-handler
   ansible.builtin.apt:

--- a/tasks/dns.yml
+++ b/tasks/dns.yml
@@ -3,6 +3,7 @@
 - name: Set hostname
   ansible.builtin.hostname:
     name: "{{ inventory_hostname }}"
+    use: "{{ hostname_strategy }}"
   when: not inventory_hostname is match('(\d{1,3}\.){3}\d{1,3}')
 
 - name: Set hostname in /etc/hosts  # noqa no-tabs

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -1,8 +1,15 @@
 ---
+- name: Check if LTS enablement package exists
+  ansible.builtin.command:
+    cmd: "apt show linux-generic-hwe-{{ ansible_distribution_version }}"
+  changed_when: false
+  failed_when: false
+  register: _check_lts_package
 
 - name: Install LTS enablement stack on ubuntu
   ansible.builtin.apt:
     pkg: "linux-generic-hwe-{{ ansible_distribution_version }}"
+  when: _check_lts_package.rc == 0
 
 - name: Check for motd news config file
   ansible.builtin.stat:

--- a/templates/sources.list.debian
+++ b/templates/sources.list.debian
@@ -4,13 +4,18 @@
 {% else %}
   {% set _security_distribution = ansible_distribution_release + "/updates" %}
 {% endif %}
+{% if ansible_distribution_version is version("12", ">=") %}
+  {% set _non_free_component = "non-free-firmware" %}
+{% else %}
+  {% set _non_free_component = "non-free" %}
+{% endif %}
 # {{ ansible_managed }}
 
-deb {{ debian_mirror }} {{ ansible_distribution_release }} main contrib non-free
-deb-src {{ debian_mirror }} {{ ansible_distribution_release }} main contrib non-free
+deb {{ debian_mirror }} {{ ansible_distribution_release }} main contrib {{ _non_free_component }}
+deb-src {{ debian_mirror }} {{ ansible_distribution_release }} main contrib {{ _non_free_component }}
 
-deb http://security.debian.org/debian-security {{ _security_distribution }} main contrib non-free
-deb-src http://security.debian.org/debian-security {{ _security_distribution }} main contrib non-free
+deb http://security.debian.org/debian-security {{ _security_distribution }} main contrib {{ _non_free_component }}
+deb-src http://security.debian.org/debian-security {{ _security_distribution }} main contrib {{ _non_free_component }}
 
-deb {{ debian_mirror }} {{ ansible_distribution_release }}-updates main contrib non-free
-deb-src {{ debian_mirror }} {{ ansible_distribution_release }}-updates main contrib non-free
+deb {{ debian_mirror }} {{ ansible_distribution_release }}-updates main contrib {{ _non_free_component }}
+deb-src {{ debian_mirror }} {{ ansible_distribution_release }}-updates main contrib {{ _non_free_component }}

--- a/templates/sources.list.debian-backports
+++ b/templates/sources.list.debian-backports
@@ -1,0 +1,9 @@
+#jinja2: trim_blocks: "false", lstrip_blocks: "true"
+{% if ansible_distribution_version is version("12", ">=") %}
+  {% set _non_free_component = "non-free-firmware" %}
+{% else %}
+  {% set _non_free_component = "non-free" %}
+{% endif %}
+# {{ ansible_managed }}
+
+deb {{ debian_mirror }} {{ ansible_distribution_release }}-backports main contrib {{ _non_free_component }}

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 ansible
-molecule-docker==2.0.0
-molecule[docker]
+molecule
+molecule-plugins[docker]


### PR DESCRIPTION
See: https://www.debian.org/releases/bookworm/amd64/release-notes/ch-information.en.html#non-free-split