### PR TITLE
Fix task that creates hostname entry in /etc/hosts.

### DIFF
--- a/tasks/dns.yml
+++ b/tasks/dns.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Set hostname
   ansible.builtin.hostname:
     name: "{{ inventory_hostname }}"
@@ -9,7 +8,8 @@
 - name: Set hostname in /etc/hosts  # noqa no-tabs
   ansible.builtin.lineinfile:
     dest: /etc/hosts
-    regexp: "^127.0.1.1.+$"
+    regexp: '^127\.0\.1\.1(.+)$'
+    insertafter: '^127\.0\.0\.1'
     line: "127.0.1.1	{{ inventory_hostname }} {{ inventory_hostname_short }}"
 
 - name: Set mailname in /etc/mailname


### PR DESCRIPTION
  * Escape periods in the regex
  * Insert entry after localhost not EOF if entry doesn't already exit.